### PR TITLE
fixing build on mac OS Big Sur

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ sklearn==0.0
 Sphinx==1.7.0
 expm==0.1.5
 lfig
-qutip==4.2.0 # Not strictly needed and causes errors during install
+git+git://github.com/ProjectQ-Framework/ProjectQ.git@master
+git+git://github.com/qutip/qutip.git@master


### PR DESCRIPTION
On max OS Big Sur there is dependency issue for ProjectQ (see here: https://github.com/ProjectQ-Framework/ProjectQ/issues/382) which causes QMLA build to fail. 

Also, the qutip==4.2.0 dependency causes the installation to fail. 

Updating to GitHub master branch for both fixes the build and I think this should be platform agnostic. 

This request modifies requirements.txt so that:
- latest version of ProjectQ  
- latest version of qutip 